### PR TITLE
Add modern CV webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Armando Capcha Chávez - CV</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <h1>Armando Capcha Chávez</h1>
+        <p>Licenciado en Psicología</p>
+        <p class="contacto">Santa Anita - Lima / Celular: +51 997113824 / <a href="mailto:apariciocch@gmail.com">apariciocch@gmail.com</a></p>
+    </header>
+
+    <main class="contenido">
+        <section>
+            <h2>Acerca de mí</h2>
+            <p>Bachiller en Psicología con experiencia en intervención terapéutica, prevención del consumo de drogas y coordinación administrativa. Con formación en Terapia Cognitivo Conductual, manejo de clientes difíciles y tutoría educativa. He desarrollado habilidades en gestión de programas comunitarios y apoyo emocional, orientado a promover la adherencia al tratamiento y el bienestar.</p>
+        </section>
+
+        <section>
+            <h2>Educación</h2>
+            <ul>
+                <li><strong>Universidad De Huánuco</strong>, Huánuco - Licenciado en Psicología (Marzo 2014 - Diciembre 2019)</li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>Capacitaciones y Cursos de Especialización</h2>
+            <ul>
+                <li>Ministerio de la Mujer y Poblaciones Vulnerables - Curso "Intervención Especializada Para La Protección De Niñas, Niños Y Adolescentes" (Febrero - Marzo 2025, 48h)</li>
+                <li>Instituto Nacional de Salud - Curso "Evaluación De Riesgos Psicosociales Laborales Metodología Censopas - Copsoq" (Marzo 2023, 16h)</li>
+                <li>Escuela Americana de Innovación - Comunicación Efectiva y Asertiva (Enero - Marzo 2024, 120h)</li>
+                <li>Escuela Americana de Innovación - Terapia Cognitivo Conductual (Octubre 2022 - Enero 2023, 240h)</li>
+                <li>Escuela Americana de Innovación - Psicología Clínica (Noviembre 2022 - Enero 2023, 240h)</li>
+                <li>DEVIDA - Habilidades Socioemocionales Para Fomentar La Adherencia Al Tratamiento Del Abuso De Drogas (Noviembre - Diciembre 2023, 40h)</li>
+                <li>DEVIDA - Motivación Al Cambio Para Desarrollar La Adherencia Al Tratamiento Por Consumo De Drogas (Agosto - Septiembre 2023, 60h)</li>
+                <li>DEVIDA - Fundamentos Teóricos De Las Comorbilidades En Las Adicciones (Abril - Mayo 2023, 80h)</li>
+                <li>DEVIDA - Entrenamiento En Tratamiento En Drogodependencia Treatnet Volumen B (Junio - Julio 2021, 32h)</li>
+                <li>DEVIDA - Técnicas Y Herramientas Para El Facilitador Comunitario En Prevención Del Consumo De Drogas (Junio - Julio 2022, 32h)</li>
+                <li>DEVIDA - Documento Técnico De Orientación, Consejería E Intervención Breve Para Consumidores De Sustancias Psicoactivas (Noviembre - Diciembre 2022, 32h)</li>
+                <li>DEVIDA - Modelos De Participación Comunitaria Para La Prevención Del Consumo De Drogas (Junio - Julio 2022, 40h)</li>
+                <li>Ministerio De Desarrollo E Inclusión Social - Gestión Para El Desarrollo E Inclusión Social (Abril - Junio 2023, 40h)</li>
+                <li>Ministerio De Desarrollo E Inclusión Social - Inducción A La Protección De Las Personas Adultas Mayores Y Las Personas Con Discapacidad (Mayo - Julio 2022, 40h)</li>
+                <li>Oracle Next Education - Formación Front End G3 (Agosto 2022 - Febrero 2023, 109h)</li>
+                <li>Fundación Romero - Microsoft Excel Intermedio (Agosto 2022, 16h)</li>
+                <li>Fundación Romero - Microsoft Word Intermedio (Agosto 2022, 16h)</li>
+                <li>Fundación Romero - Microsoft Power Point Intermedio (Agosto 2022, 16h)</li>
+                <li>King's College London - Inglés Básico (2020)</li>
+                <li>Udemy - Canva Diseño (Marzo - Abril 2022)</li>
+                <li>AlbatrossCloud - HTML, CSS; Git y GitHub Fundamentals; Trello Support Help Desk; Sistemas Operativos Windows y Ubuntu; Microsoft Office; Google Suite Empresas (Agosto - Octubre 2015)</li>
+                <li>Teleatento del Perú S.A.C - Escuela de CROSS SELLING (Enero 2015)</li>
+                <li>Coursera - Diversos cursos de Psicología y Salud Mental (2021-2023)</li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>Experiencia Laboral</h2>
+            <ul>
+                <li><strong>Colegio Saco Oliveros Helicoidal</strong> - Tutor Académico (Marzo 2023 - Diciembre 2023)</li>
+                <li><strong>Albatross Cloud S.A.C</strong> - Documentación de Manuales de Software de Gestión Documental (Julio 2022 - Diciembre 2022)</li>
+                <li><strong>Ministerio de Salud Central 113 Salud / Atento del Perú</strong> - Orientador Línea 113 Salud (Mayo 2021 - Enero 2022)</li>
+                <li><strong>Albatross Cloud S.A.C</strong> - Coordinador Administrativo de la Oficina (Agosto 2015 - Octubre 2020)</li>
+                <li><strong>Arena Verde S.A.C</strong> - Administrador de Correos</li>
+                <li><strong>Rivera Contable</strong> - Administrador de Correos Electrónicos</li>
+                <li><strong>Perú Champs</strong> - Administración y Actualización de Portal Web</li>
+                <li><strong>Universidad Nacional Agraria La Molina</strong> - Coordinador Administrativo</li>
+                <li><strong>Teleatento del Perú S.A.C</strong> - Asesor de Servicio al Cliente (Agosto 2010 - Julio 2015)</li>
+            </ul>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p>&copy; 2024 Armando Capcha Chávez</p>
+        <button id="modo-btn">Modo oscuro</button>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,4 @@
+document.getElementById('modo-btn').addEventListener('click', function() {
+    document.documentElement.classList.toggle('dark-mode');
+    this.textContent = document.documentElement.classList.contains('dark-mode') ? 'Modo claro' : 'Modo oscuro';
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,91 @@
+body {
+    font-family: 'Roboto', sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+.header {
+    background-color: #2c3e50;
+    color: #fff;
+    text-align: center;
+    padding: 2rem 1rem;
+}
+
+.header h1 {
+    margin: 0;
+    font-size: 2.5rem;
+}
+
+.header .contacto a {
+    color: #ecf0f1;
+    text-decoration: none;
+}
+
+.contenido {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+}
+
+section {
+    margin-bottom: 2rem;
+}
+
+h2 {
+    border-bottom: 2px solid #2c3e50;
+    padding-bottom: 0.5rem;
+    margin-bottom: 1rem;
+    color: #2c3e50;
+}
+
+ul {
+    list-style: none;
+    padding: 0;
+}
+
+li {
+    margin-bottom: 0.5rem;
+}
+
+.footer {
+    background-color: #2c3e50;
+    color: #fff;
+    text-align: center;
+    padding: 1rem;
+}
+
+#modo-btn {
+    margin-top: 1rem;
+    padding: 0.5rem 1rem;
+    border: none;
+    background-color: #3498db;
+    color: #fff;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.dark-mode body {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+}
+
+.dark-mode .header,
+.dark-mode .footer {
+    background-color: #000;
+}
+
+.dark-mode h2 {
+    border-color: #555;
+    color: #e0e0e0;
+}
+
+.dark-mode #modo-btn {
+    background-color: #555;
+}
+
+body, .header, .footer {
+    transition: background-color 0.3s, color 0.3s;
+}


### PR DESCRIPTION
## Summary
- implement a modern single-page curriculum vitae
- add styling with light and dark modes
- provide a small script to toggle the theme

## Testing
- `apt-get update`
- `apt-get install -y vim`


------
https://chatgpt.com/codex/tasks/task_e_683f958d1b908328ae7dd6d110cd317e