### PR TITLE
Move profile image to about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,13 +14,15 @@
             <p>Licenciado en Psicología</p>
             <p class="contacto">Santa Anita - Lima / <a href="https://www.linkedin.com/in/apariciocch/" target="_blank">LinkedIn</a> / <a href="mailto:apariciocch@gmail.com">apariciocch@gmail.com</a></p>
         </div>
-        <img src="img/IMAGEN1.jpg" alt="Foto de Aparicio Armando Capcha Chávez" class="profile-pic">
     </header>
 
     <main class="contenido">
-        <section>
-            <h2>Acerca de mí</h2>
-            <p>Licenciado en Psicología con experiencia en intervención terapéutica, prevención del consumo de drogas y coordinación administrativa. Con formación en Terapia Cognitivo Conductual, manejo de clientes difíciles y tutoría educativa. He desarrollado habilidades en gestión de programas comunitarios y apoyo emocional, orientado a promover la adherencia al tratamiento y el bienestar.</p>
+        <section class="acerca">
+            <img src="img/IMAGEN1.jpg" alt="Foto de Aparicio Armando Capcha Chávez" class="profile-pic">
+            <div>
+                <h2>Acerca de mí</h2>
+                <p>Licenciado en Psicología con experiencia en intervención terapéutica, prevención del consumo de drogas y coordinación administrativa. Con formación en Terapia Cognitivo Conductual, manejo de clientes difíciles y tutoría educativa. He desarrollado habilidades en gestión de programas comunitarios y apoyo emocional, orientado a promover la adherencia al tratamiento y el bienestar.</p>
+            </div>
         </section>
 
         <section>

--- a/style.css
+++ b/style.css
@@ -48,6 +48,12 @@ section {
     margin-bottom: 2rem;
 }
 
+.acerca {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
 h2 {
     border-bottom: 2px solid #2c3e50;
     padding-bottom: 0.5rem;


### PR DESCRIPTION
## Summary
- repositioned the profile picture from the header into the first content block
- styled new `.acerca` section so the image appears on the left

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fa2950ce4832898be2c1bc90c0a1f